### PR TITLE
Update __init__.py (#469)

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -468,7 +468,7 @@ class Job(object):
             The format must make sense given how often the job is
             repeating; for example, a job that repeats every minute
             should not be given a string in the form `HH:MM:SS`. The
-            difference between `:MM` and :SS` is inferred from the
+            difference between `:MM` and `:SS` is inferred from the
             selected time-unit (e.g. `every().hour.at(':30')` vs.
             `every().minute.at(':30')`).
 


### PR DESCRIPTION
Fix missing back-tick symbol in the docstring of the `at()` method.